### PR TITLE
Fix: can retry tournament level if retiring after collecting all arrowheads

### DIFF
--- a/Source/System/Main.c
+++ b/Source/System/Main.c
@@ -434,7 +434,8 @@ short	placeToWin,startStage;
 			bool hasAllTokens = (gTotalTokens >= MAX_TOKENS);
 			bool objectiveCompleted = hasGoodPosition && hasAllTokens;
 
-			if (hasGoodPosition) {
+			if (hasGoodPosition)
+			{
 				TallyTokens(); // Only tally if finished in high enough race position!
 			}
 

--- a/Source/System/Main.c
+++ b/Source/System/Main.c
@@ -428,12 +428,14 @@ short	placeToWin,startStage;
 			InitArea();
 			PlayArea();
 
-			bool objectiveCompleted = (gPlayerInfo[0].place <= placeToWin) && (gTotalTokens >= MAX_TOKENS);
+			// Added variables to keep track of separate objectives.
+			// (Allows us to fix bug whereby game returns to main menu if player collects all arrowheads but fails race)
+			bool hasGoodPosition = (gPlayerInfo[0].place <= placeToWin);
+			bool hasAllTokens = (gTotalTokens >= MAX_TOKENS);
+			bool objectiveCompleted = hasGoodPosition && hasAllTokens;
 
-			if (gPlayerInfo[0].place <= placeToWin)									// if came in 1st place then tally tokens
-			{
-				TallyTokens();
-				objectiveCompleted = (gTotalTokens >= MAX_TOKENS);
+			if (hasGoodPosition) {
+				TallyTokens(); // Only tally if finished in high enough race position!
 			}
 
 					/* SEE IF DIDNT COME IN 1ST PLACE OR DIDNT GET ALL THE TOKENS */

--- a/Source/System/Main.c
+++ b/Source/System/Main.c
@@ -428,15 +428,14 @@ short	placeToWin,startStage;
 			InitArea();
 			PlayArea();
 
-			// Added variables to keep track of separate objectives.
-			// (Allows us to fix bug whereby game returns to main menu if player collects all arrowheads but fails race)
+			// Added variables to keep track of separate objectives
 			bool hasGoodPosition = (gPlayerInfo[0].place <= placeToWin);
 			bool hasAllTokens = (gTotalTokens >= MAX_TOKENS);
-			bool objectiveCompleted = hasGoodPosition && hasAllTokens;
+			bool objectiveCompleted = hasGoodPosition && hasAllTokens && gPlayerInfo[0].raceComplete;
 
-			if (hasGoodPosition)
+			if (hasGoodPosition && gPlayerInfo[0].raceComplete)
 			{
-				TallyTokens(); // Only tally if finished in high enough race position!
+				TallyTokens(); // Only tally if finished and in high enough race position!
 			}
 
 					/* SEE IF DIDNT COME IN 1ST PLACE OR DIDNT GET ALL THE TOKENS */


### PR DESCRIPTION
Previously, the game would return to the main menu if the player collected all arrowheads, but failed to finish the race in a sufficient position.