### PR TITLE
Fix: prevent phantom driving if reversing while nitro used

### DIFF
--- a/Source/Player/Player_Car.c
+++ b/Source/Player/Player_Car.c
@@ -2888,6 +2888,9 @@ float			fps = gFramesPerSecondFrac;
 
 	if (gPlayerInfo[playerNum].nitroTimer > 0.0f)
 	{
+		// Prevents phantom driving if nitro is used when reversing
+		gPlayerInfo[playerNum].accelBackwards = false; 
+
 		gPlayerInfo[playerNum].braking = false;
 		gPlayerInfo[playerNum].gasPedalDown = true;
 		thrust = NITRO_ACCELERATION;


### PR DESCRIPTION
This is a bug that seems to result from conflicting forces acting on the vehicle, causing the car to move sideways on its own and preventing the player from moving forward normally.

[Video of bug](https://www.youtube.com/watch?v=93VWrYRjs9I).
 
After this simple adjustment I was unable to replicate the bug again.